### PR TITLE
Add www.dominion.games/* to list of hosts to run extension

### DIFF
--- a/domBeep/manifest.json
+++ b/domBeep/manifest.json
@@ -7,7 +7,7 @@
 
   "content_scripts": [
     {
-      "matches":["https://dominion.games/*"],
+      "matches":["https://dominion.games/*", "https://www.dominion.games/*"],
       "js":["domBeep.js"]
     }
   ]


### PR DESCRIPTION
SOME people navigate to https://www.dominion.games and not
https://dominion.games when they wanna play some dom. Add this pattern for the
www subdomain so those people get dom beeps too.